### PR TITLE
Pass Slack API token in Secret

### DIFF
--- a/helm_chart/Chart.yaml
+++ b/helm_chart/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.2
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helm_chart/templates/deployment.yaml
+++ b/helm_chart/templates/deployment.yaml
@@ -29,7 +29,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: KW_SLACK_TOKEN
-              value: "{{ .Values.slack.token }}"
+              valueFrom:
+                secretKeyRef:
+                  name: kubewise
+                  key: kw_slack_token
             - name: KW_SLACK_CHANNEL
               value: "{{ .Values.slack.channel }}"
             - name: KW_NAMESPACE

--- a/helm_chart/templates/secret.yaml
+++ b/helm_chart/templates/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubewise
+type: Opaque
+stringData:
+  kw_slack_token: "{{ .Values.slack.token }}"


### PR DESCRIPTION
Closes #13

It used to be that using `kubectl get pod -i yaml xyz` on the kubewise
pod would show the Slack API token in cleartext. With this change it is
stored in a secret instead. The external user interface doesn't change.