### PR TITLE
Simplify handlers to one method and one arg

### DIFF
--- a/handlers/googlechat/googlechat.go
+++ b/handlers/googlechat/googlechat.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/larderdev/kubewise/kwrelease"
 	"github.com/larderdev/kubewise/presenters"
-	"helm.sh/helm/v3/pkg/release"
 )
 
 type GoogleChat struct {
@@ -28,20 +28,8 @@ func (g *GoogleChat) Init() error {
 	return nil
 }
 
-func (g *GoogleChat) ObjectCreated(currentRelease, previousRelease *release.Release) {
-	if msg := presenters.PrepareObjectCreatedMsg(currentRelease, previousRelease); msg != "" {
-		makeRequest(g, msg)
-	}
-}
-
-func (g *GoogleChat) ObjectDeleted(currentRelease, previousRelease *release.Release) {
-	if msg := presenters.PrepareObjectDeletedMsg(currentRelease, previousRelease); msg != "" {
-		makeRequest(g, msg)
-	}
-}
-
-func (g *GoogleChat) ObjectUpdated(currentRelease, previousRelease *release.Release) {
-	if msg := presenters.PrepareObjectUpgradedMsg(currentRelease, previousRelease); msg != "" {
+func (g *GoogleChat) HandleEvent(releaseEvent *kwrelease.Event) {
+	if msg := presenters.PrepareMsg(releaseEvent); msg != "" {
 		makeRequest(g, msg)
 	}
 }

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -26,14 +26,12 @@ package handlers
 import (
 	"github.com/larderdev/kubewise/handlers/googlechat"
 	"github.com/larderdev/kubewise/handlers/slack"
-	"helm.sh/helm/v3/pkg/release"
+	"github.com/larderdev/kubewise/kwrelease"
 )
 
 type Handler interface {
 	Init() error
-	ObjectCreated(currentRelease, previousRelease *release.Release)
-	ObjectDeleted(currentRelease, previousRelease *release.Release)
-	ObjectUpdated(currentRelease, previousRelease *release.Release)
+	HandleEvent(releaseEvent *kwrelease.Event)
 }
 
 var Map = map[string]interface{}{
@@ -49,14 +47,6 @@ func (d *Default) Init() error {
 	return nil
 }
 
-func (d *Default) ObjectCreated(currentRelease, previousRelease *release.Release) {
-
-}
-
-func (d *Default) ObjectDeleted(currentRelease, previousRelease *release.Release) {
-
-}
-
-func (d *Default) ObjectUpdated(currentRelease, previousRelease *release.Release) {
+func (d *Default) HandleEvent(releaseEvent *kwrelease.Event) {
 
 }

--- a/handlers/slack/slack.go
+++ b/handlers/slack/slack.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"os"
 
+	"github.com/larderdev/kubewise/kwrelease"
 	"github.com/larderdev/kubewise/presenters"
 	"github.com/slack-go/slack"
-	"helm.sh/helm/v3/pkg/release"
 )
 
 type Slack struct {
@@ -32,20 +32,8 @@ func (s *Slack) Init() error {
 	return nil
 }
 
-func (s *Slack) ObjectCreated(currentRelease, previousRelease *release.Release) {
-	if msg := presenters.PrepareObjectCreatedMsg(currentRelease, previousRelease); msg != "" {
-		sendMessage(s, msg)
-	}
-}
-
-func (s *Slack) ObjectDeleted(currentRelease, previousRelease *release.Release) {
-	if msg := presenters.PrepareObjectDeletedMsg(currentRelease, previousRelease); msg != "" {
-		sendMessage(s, msg)
-	}
-}
-
-func (s *Slack) ObjectUpdated(currentRelease, previousRelease *release.Release) {
-	if msg := presenters.PrepareObjectUpgradedMsg(currentRelease, previousRelease); msg != "" {
+func (s *Slack) HandleEvent(releaseEvent *kwrelease.Event) {
+	if msg := presenters.PrepareMsg(releaseEvent); msg != "" {
 		sendMessage(s, msg)
 	}
 }

--- a/presenters/presenters.go
+++ b/presenters/presenters.go
@@ -3,98 +3,59 @@ package presenters
 import (
 	"fmt"
 
-	"helm.sh/helm/v3/pkg/release"
+	"github.com/larderdev/kubewise/kwrelease"
 )
 
-func PrepareObjectCreatedMsg(currentRelease, previousRelease *release.Release) string {
-	var msg string
-
-	if currentRelease.Info.Status == release.StatusPendingInstall {
-		msg = fmt.Sprintf(
-			"💽 Installing *%s* version *%s* into namespace *%s* via Helm. ⏳\n\n%s",
-			currentRelease.Name,
-			currentRelease.Chart.AppVersion(),
-			currentRelease.Namespace,
-			currentRelease.Info.Description,
+func PrepareMsg(releaseEvent *kwrelease.Event) string {
+	switch releaseEvent.GetAction() {
+	case kwrelease.ActionPreInstall:
+		return fmt.Sprintf("💽 Installing *%s* version *%s* into namespace *%s* via Helm. ⏳\n\n%s",
+			releaseEvent.GetAppName(),
+			releaseEvent.GetAppVersion(),
+			releaseEvent.GetNamespace(),
+			releaseEvent.GetDescription(),
 		)
-	} else if currentRelease.Info.Status == release.StatusPendingUpgrade {
-		if previousRelease == nil {
-			msg = fmt.Sprintf(
-				"⏫ Upgrading *%s* to version *%s* in namespace *%s* via Helm. ⏳",
-				currentRelease.Name,
-				currentRelease.Chart.AppVersion(),
-				currentRelease.Namespace,
-			)
-		} else {
-			msg = fmt.Sprintf(
-				"⏫ Upgrading *%s* from version %s to version *%s* in namespace *%s* via Helm. ⏳",
-				currentRelease.Name,
-				previousRelease.Chart.AppVersion(),
-				currentRelease.Chart.AppVersion(),
-				currentRelease.Namespace,
-			)
-		}
-	} else if currentRelease.Info.Status == release.StatusPendingRollback {
-		if previousRelease == nil {
-			msg = fmt.Sprintf(
-				"⏬ Rolling back *%s* from version %s in namespace *%s* via Helm. ⏳",
-				currentRelease.Name,
-				currentRelease.Chart.AppVersion(),
-				currentRelease.Namespace,
-			)
-		} else {
-			msg = fmt.Sprintf(
-				"⏫ Rolling back *%s* from version %s to version *%s* in namespace *%s* via Helm. ⏳",
-				currentRelease.Name,
-				previousRelease.Chart.AppVersion(),
-				currentRelease.Chart.AppVersion(),
-				currentRelease.Namespace,
-			)
-		}
-	}
 
-	return msg
-}
-
-func PrepareObjectDeletedMsg(currentRelease, previousRelease *release.Release) string {
-	return ""
-}
-
-func PrepareObjectUpgradedMsg(currentRelease, previousRelease *release.Release) string {
-	var msg string
-
-	if currentRelease.Info.Status == release.StatusDeployed {
-		if previousRelease == nil {
-			msg = fmt.Sprintf(
-				"💽 Successfully installed *%s* version *%s* into namespace *%s* via Helm. ✅\n\n```%s```",
-				currentRelease.Name,
-				currentRelease.Chart.AppVersion(),
-				currentRelease.Namespace,
-				currentRelease.Info.Notes,
-			)
-		} else {
-			// There is no way to tell if this is an upgrade or a rollback. The previous release
-			// status will be changed to "superseeded" and the new release will have the status
-			// "deployed". Versions are arbitrary strings so we can't compare them against each
-			// other.
-			// Best I can do is use neutral language like "replaced".
-			msg = fmt.Sprintf(
-				"⏫ Successfully replaced *%s* version %s with version *%s* in namespace *%s* via Helm. ✅\n\n```%s```",
-				currentRelease.Name,
-				previousRelease.Chart.AppVersion(),
-				currentRelease.Chart.AppVersion(),
-				currentRelease.Namespace,
-				currentRelease.Info.Notes,
-			)
-		}
-	} else if currentRelease.Info.Status == release.StatusUninstalling {
-		msg = fmt.Sprintf(
-			"🧼 Uninstalling *%s* version *%s* from namespace %s via Helm.",
-			currentRelease.Name,
-			currentRelease.Chart.AppVersion(),
-			currentRelease.Namespace,
+	case kwrelease.ActionPreReplaceUpgrade:
+		return fmt.Sprintf("⏫ Upgrading *%s* from version %s to version *%s* in namespace *%s* via Helm. ⏳",
+			releaseEvent.GetAppName(),
+			releaseEvent.GetPreviousAppVersion(),
+			releaseEvent.GetAppVersion(),
+			releaseEvent.GetNamespace(),
 		)
-	}
 
-	return msg
+	case kwrelease.ActionPreReplaceRollback:
+		return fmt.Sprintf("⏬ Rolling back *%s* from version %s to version *%s* in namespace *%s* via Helm. ⏳",
+			releaseEvent.GetAppName(),
+			releaseEvent.GetPreviousAppVersion(),
+			releaseEvent.GetAppVersion(),
+			releaseEvent.GetNamespace(),
+		)
+
+	case kwrelease.ActionPreUninstall:
+		return fmt.Sprintf("🧼 Uninstalling *%s* from namespace *%s* via Helm. ⏳",
+			releaseEvent.GetAppName(),
+			releaseEvent.GetNamespace(),
+		)
+
+	case kwrelease.ActionPostInstall:
+		return fmt.Sprintf("Installed *%s* version *%s* into namespace *%s* via Helm. ✅\n\n```%s```",
+			releaseEvent.GetAppName(),
+			releaseEvent.GetAppVersion(),
+			releaseEvent.GetNamespace(),
+			releaseEvent.GetNotes(),
+		)
+
+	case kwrelease.ActionPostReplace:
+		return fmt.Sprintf("Replaced *%s* version %s with version *%s* in namespace *%s* via Helm. ✅\n\n```%s```",
+			releaseEvent.GetAppName(),
+			releaseEvent.GetPreviousAppVersion(),
+			releaseEvent.GetAppVersion(),
+			releaseEvent.GetNamespace(),
+			releaseEvent.GetNotes(),
+		)
+
+	default:
+		return ""
+	}
 }


### PR DESCRIPTION
This commit makes it simpler to add more handlers in the future. They no
longer need to accpet two release objects and compare them to decide
what to do. Instead, they accept one releaseEvent which contains all the
state needed to describe the Helm event which just occurred.

This makes for much more understandable handers.