### PR TITLE
Improve message description

### DIFF
--- a/kwrelease/kwrelease.go
+++ b/kwrelease/kwrelease.go
@@ -56,7 +56,7 @@ func (e *Event) GetNamespace() string {
 }
 
 func (e *Event) GetDescription() string {
-	return e.currentRelease.Info.Description
+	return e.currentRelease.Chart.Metadata.Description
 }
 
 func (e *Event) GetNotes() string {

--- a/presenters/json.go
+++ b/presenters/json.go
@@ -20,20 +20,20 @@ type EventJSON struct {
 
 func ReleaseEventToJSON(e *kwrelease.Event) ([]byte, error) {
 	event := EventJSON{
-		AppName:            e.GetAppName(),
-		AppVersion:         e.GetAppVersion(),
-		Namespace:          e.GetNamespace(),
-		Action:             e.GetAction().String(),
-		InstallNotes:       e.GetNotes(),
-		AppDescription:     e.GetDescription(),
+		AppName:        e.GetAppName(),
+		AppVersion:     e.GetAppVersion(),
+		Namespace:      e.GetNamespace(),
+		Action:         e.GetAction().String(),
+		InstallNotes:   e.GetNotes(),
+		AppDescription: e.GetDescription(),
 	}
 
-  previousAppVersion := e.GetPreviousAppVersion()
+	previousAppVersion := e.GetPreviousAppVersion()
 
-  // Prevents an empty string value in the JSON.
-  if previousAppVersion != "" {
+	// Prevents an empty string value in the JSON.
+	if previousAppVersion != "" {
 		event.PreviousAppVersion = previousAppVersion
-  }
+	}
 
 	if value, ok := os.LookupEnv("KW_MESSAGE_PREFIX"); ok && value != "" {
 		event.MessagePrefix = value


### PR DESCRIPTION
Found a small bug where the wrong description was being pulled from the Helm secrets and displayed to the user.

For ZooKeeper, for example, the user would see "Deletion in progress (or silently failed)" instead of "Centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services."