### PR TITLE
Differenciate rollbacks

### DIFF
--- a/kwrelease/action.go
+++ b/kwrelease/action.go
@@ -3,10 +3,14 @@ package kwrelease
 type Action string
 
 const (
-	ActionPreInstall            Action = "PRE_INSTALL"
-	ActionPreReplaceUpgrade     Action = "PRE_REPLACE-UPGRADE"
-	ActionPreReplaceRollback    Action = "PRE_REPLACE-ROLLBACK"
-	ActionPostInstall           Action = "POST_INSTALL"
+	ActionPreInstall   Action = "PRE_INSTALL"
+	ActionPreRollback  Action = "PRE_ROLLBACK"
+	ActionPreUpgrade   Action = "PRE_UPGRADE"
+	ActionPostInstall  Action = "POST_INSTALL"
+	ActionPostUpgrade  Action = "POST_UPGRADE"
+	ActionPostRollback Action = "POST_ROLLBACK"
+	// Because string matching is a dangerous game, we should have a fallback for times we
+	// can't tell if the operation was an Upgrade or a Rollback.
 	ActionPostReplace           Action = "POST_REPLACE"
 	ActionPostReplaceSuperseded Action = "POST_REPLACE-SUPERSEDED"
 	ActionPreUninstall          Action = "PRE_UNINSTALL"

--- a/kwrelease/kwrelease.go
+++ b/kwrelease/kwrelease.go
@@ -67,18 +67,17 @@ func (e *Event) GetAction() Action {
 	if e.currentRelease.Info.Status == release.StatusPendingInstall {
 		return ActionPreInstall
 	} else if e.currentRelease.Info.Status == release.StatusPendingUpgrade {
-		return ActionPreReplaceUpgrade
+		return ActionPreUpgrade
 	} else if e.currentRelease.Info.Status == release.StatusPendingRollback {
-		return ActionPreReplaceRollback
+		return ActionPreRollback
 	} else if e.currentRelease.Info.Status == release.StatusDeployed {
 		if e.previousRelease == nil {
 			return ActionPostInstall
+		} else if strings.HasPrefix(e.currentRelease.Info.Description, "Rollback") {
+			return ActionPostRollback
+		} else if strings.HasPrefix(e.currentRelease.Info.Description, "Upgrade") {
+			return ActionPostUpgrade
 		}
-		// There is no way to tell if this is an upgrade or a rollback. The previous release
-		// status will be changed to "superseeded" and the new release will have the status
-		// "deployed". Versions are arbitrary strings so we can't compare them against each
-		// other.
-		// Best I can do is use neutral language like "replaced".
 		return ActionPostReplace
 	} else if e.currentRelease.Info.Status == release.StatusSuperseded {
 		return ActionPostReplaceSuperseded

--- a/presenters/presenters.go
+++ b/presenters/presenters.go
@@ -23,7 +23,7 @@ func PrepareMsg(releaseEvent *kwrelease.Event) string {
 			releaseEvent.GetDescription(),
 		)
 
-	case kwrelease.ActionPreReplaceUpgrade:
+	case kwrelease.ActionPreUpgrade:
 		msg += fmt.Sprintf("⏫ Upgrading *%s* from version %s to version *%s* in namespace *%s* via Helm. ⏳",
 			releaseEvent.GetAppName(),
 			releaseEvent.GetPreviousAppVersion(),
@@ -31,7 +31,7 @@ func PrepareMsg(releaseEvent *kwrelease.Event) string {
 			releaseEvent.GetNamespace(),
 		)
 
-	case kwrelease.ActionPreReplaceRollback:
+	case kwrelease.ActionPreRollback:
 		msg += fmt.Sprintf("⏬ Rolling back *%s* from version %s to version *%s* in namespace *%s* via Helm. ⏳",
 			releaseEvent.GetAppName(),
 			releaseEvent.GetPreviousAppVersion(),
@@ -46,8 +46,26 @@ func PrepareMsg(releaseEvent *kwrelease.Event) string {
 		)
 
 	case kwrelease.ActionPostInstall:
-		msg += fmt.Sprintf("Installed *%s* version *%s* into namespace *%s* via Helm. ✅\n\n```%s```",
+		msg += fmt.Sprintf("📀 Installed *%s* version *%s* into namespace *%s* via Helm. ✅\n\n```%s```",
 			releaseEvent.GetAppName(),
+			releaseEvent.GetAppVersion(),
+			releaseEvent.GetNamespace(),
+			releaseEvent.GetNotes(),
+		)
+
+	case kwrelease.ActionPostUpgrade:
+		msg += fmt.Sprintf("⏫ Upgraded *%s* from version %s to version *%s* in namespace *%s* via Helm. ✅\n\n```%s```",
+			releaseEvent.GetAppName(),
+			releaseEvent.GetPreviousAppVersion(),
+			releaseEvent.GetAppVersion(),
+			releaseEvent.GetNamespace(),
+			releaseEvent.GetNotes(),
+		)
+
+	case kwrelease.ActionPostRollback:
+		msg += fmt.Sprintf("⏬ Rolled back *%s* from version %s to version *%s* in namespace *%s* via Helm. ✅\n\n```%s```",
+			releaseEvent.GetAppName(),
+			releaseEvent.GetPreviousAppVersion(),
 			releaseEvent.GetAppVersion(),
 			releaseEvent.GetNamespace(),
 			releaseEvent.GetNotes(),


### PR DESCRIPTION
There is no Helm secret state to differenciate Upgrades from Rollbacks
but it turns out it can be done by string matching on the
Info.Description. It's not ideal because the strings could change but
it's the best that can be done for the moment.