### PR TITLE
Display chart versions in messages

### DIFF
--- a/kwrelease/kwrelease.go
+++ b/kwrelease/kwrelease.go
@@ -89,6 +89,21 @@ func (e *Event) GetLabelsModifiedAtTimestamp() meta_v1.Time {
 	return meta_v1.Unix(i, 0)
 }
 
+func (e *Event) GetChartVersion() string {
+	return e.currentRelease.Chart.Metadata.Version
+}
+
+func (e *Event) GetPreviousChartVersion() string {
+	if e.previousRelease != nil {
+		return e.previousRelease.Chart.Metadata.Version
+	}
+	return ""
+}
+
+func (e *Event) IsAppVersionChanged() bool {
+	return e.GetAppVersion() != e.GetPreviousAppVersion()
+}
+
 func (e *Event) GetAction() Action {
 	if e.currentRelease.Info.Status == release.StatusPendingInstall {
 		return ActionPreInstall

--- a/presenters/json.go
+++ b/presenters/json.go
@@ -13,29 +13,33 @@ import (
 // Secret MetaData) because it makes more sense for users of the webhooks. The user wants to
 // know what time the event occurred as a first class concept in the Json.
 type EventJSON struct {
-	AppName            string       `json:"appName"`
-	AppVersion         string       `json:"appVersion"`
-	Namespace          string       `json:"namespace"`
-	PreviousAppVersion string       `json:"previousAppVersion"`
-	Action             string       `json:"action"`
-	AppDescription     string       `json:"appDescription"`
-	InstallNotes       string       `json:"installNotes"`
-	MessagePrefix      string       `json:"messagePrefix"`
-	CreatedAt          meta_v1.Time `json:"createdAt"`
-	UpdatedAt          meta_v1.Time `json:"updatedAt"`
-	SecretUID          types.UID    `json:"secretUid"`
+	AppName              string       `json:"appName"`
+	AppVersion           string       `json:"appVersion"`
+	Namespace            string       `json:"namespace"`
+	PreviousAppVersion   string       `json:"previousAppVersion"`
+	Action               string       `json:"action"`
+	AppDescription       string       `json:"appDescription"`
+	InstallNotes         string       `json:"installNotes"`
+	MessagePrefix        string       `json:"messagePrefix"`
+	CreatedAt            meta_v1.Time `json:"createdAt"`
+	UpdatedAt            meta_v1.Time `json:"updatedAt"`
+	SecretUID            types.UID    `json:"secretUid"`
+	ChartVersion         string       `json:"chartVersion"`
+	PreviousChartVersion string       `json:"previousChartVersion"`
 }
 
 func ReleaseEventToJSON(e *kwrelease.Event) ([]byte, error) {
 	event := EventJSON{
-		AppName:        e.GetAppName(),
-		AppVersion:     e.GetAppVersion(),
-		Namespace:      e.GetNamespace(),
-		Action:         e.GetAction().String(),
-		InstallNotes:   e.GetNotes(),
-		AppDescription: e.GetDescription(),
-		CreatedAt:      e.GetSecretCreationTimestamp(),
-		SecretUID:      e.GetSecretUID(),
+		AppName:              e.GetAppName(),
+		AppVersion:           e.GetAppVersion(),
+		Namespace:            e.GetNamespace(),
+		Action:               e.GetAction().String(),
+		InstallNotes:         e.GetNotes(),
+		AppDescription:       e.GetDescription(),
+		CreatedAt:            e.GetSecretCreationTimestamp(),
+		SecretUID:            e.GetSecretUID(),
+		ChartVersion:         e.GetChartVersion(),
+		PreviousChartVersion: e.GetPreviousChartVersion(),
 	}
 
 	if value := e.GetLabelsModifiedAtTimestamp(); !value.IsZero() {

--- a/presenters/presenters.go
+++ b/presenters/presenters.go
@@ -7,6 +7,21 @@ import (
 	"github.com/larderdev/kubewise/kwrelease"
 )
 
+func getChangeInAppVersion(releaseEvent *kwrelease.Event) string {
+	var appVersion string
+	if releaseEvent.IsAppVersionChanged() {
+		appVersion = fmt.Sprintf("App version will be *%s*, up from %s",
+			releaseEvent.GetAppVersion(),
+			releaseEvent.GetPreviousAppVersion(),
+		)
+	} else {
+		appVersion = fmt.Sprintf("App version will be *%s* (unchanged)",
+			releaseEvent.GetAppVersion(),
+		)
+	}
+	return appVersion
+}
+
 func PrepareMsg(releaseEvent *kwrelease.Event) string {
 	var msg string
 
@@ -16,27 +31,30 @@ func PrepareMsg(releaseEvent *kwrelease.Event) string {
 
 	switch releaseEvent.GetAction() {
 	case kwrelease.ActionPreInstall:
-		msg += fmt.Sprintf("📀 Installing *%s* version *%s* into namespace *%s* via Helm. ⏳\n\n%s",
+		msg += fmt.Sprintf("📀 Installing *%s* version *%s* into namespace *%s* via Helm. ⏳\n\nApp version: *%s*\n%s",
 			releaseEvent.GetAppName(),
-			releaseEvent.GetAppVersion(),
+			releaseEvent.GetChartVersion(),
 			releaseEvent.GetNamespace(),
+			releaseEvent.GetAppVersion(),
 			releaseEvent.GetDescription(),
 		)
 
 	case kwrelease.ActionPreUpgrade:
-		msg += fmt.Sprintf("⏫ Upgrading *%s* from version %s to version *%s* in namespace *%s* via Helm. ⏳",
+		msg += fmt.Sprintf("⏫ Upgrading *%s* from version %s to version *%s* in namespace *%s* via Helm. ⏳\n%s",
 			releaseEvent.GetAppName(),
-			releaseEvent.GetPreviousAppVersion(),
-			releaseEvent.GetAppVersion(),
+			releaseEvent.GetPreviousChartVersion(),
+			releaseEvent.GetChartVersion(),
 			releaseEvent.GetNamespace(),
+			getChangeInAppVersion(releaseEvent),
 		)
 
 	case kwrelease.ActionPreRollback:
-		msg += fmt.Sprintf("⏬ Rolling back *%s* from version %s to version *%s* in namespace *%s* via Helm. ⏳",
+		msg += fmt.Sprintf("⏬ Rolling back *%s* from version %s to version *%s* in namespace *%s* via Helm. ⏳\n%s",
 			releaseEvent.GetAppName(),
-			releaseEvent.GetPreviousAppVersion(),
-			releaseEvent.GetAppVersion(),
+			releaseEvent.GetPreviousChartVersion(),
+			releaseEvent.GetChartVersion(),
 			releaseEvent.GetNamespace(),
+			getChangeInAppVersion(releaseEvent),
 		)
 
 	case kwrelease.ActionPreUninstall:
@@ -48,7 +66,7 @@ func PrepareMsg(releaseEvent *kwrelease.Event) string {
 	case kwrelease.ActionPostInstall:
 		msg += fmt.Sprintf("📀 Installed *%s* version *%s* into namespace *%s* via Helm. ✅\n\n```%s```",
 			releaseEvent.GetAppName(),
-			releaseEvent.GetAppVersion(),
+			releaseEvent.GetChartVersion(),
 			releaseEvent.GetNamespace(),
 			releaseEvent.GetNotes(),
 		)
@@ -56,8 +74,8 @@ func PrepareMsg(releaseEvent *kwrelease.Event) string {
 	case kwrelease.ActionPostUpgrade:
 		msg += fmt.Sprintf("⏫ Upgraded *%s* from version %s to version *%s* in namespace *%s* via Helm. ✅\n\n```%s```",
 			releaseEvent.GetAppName(),
-			releaseEvent.GetPreviousAppVersion(),
-			releaseEvent.GetAppVersion(),
+			releaseEvent.GetPreviousChartVersion(),
+			releaseEvent.GetChartVersion(),
 			releaseEvent.GetNamespace(),
 			releaseEvent.GetNotes(),
 		)
@@ -65,8 +83,8 @@ func PrepareMsg(releaseEvent *kwrelease.Event) string {
 	case kwrelease.ActionPostRollback:
 		msg += fmt.Sprintf("⏬ Rolled back *%s* from version %s to version *%s* in namespace *%s* via Helm. ✅\n\n```%s```",
 			releaseEvent.GetAppName(),
-			releaseEvent.GetPreviousAppVersion(),
-			releaseEvent.GetAppVersion(),
+			releaseEvent.GetPreviousChartVersion(),
+			releaseEvent.GetChartVersion(),
 			releaseEvent.GetNamespace(),
 			releaseEvent.GetNotes(),
 		)
@@ -74,8 +92,8 @@ func PrepareMsg(releaseEvent *kwrelease.Event) string {
 	case kwrelease.ActionPostReplace:
 		msg += fmt.Sprintf("Replaced *%s* version %s with version *%s* in namespace *%s* via Helm. ✅\n\n```%s```",
 			releaseEvent.GetAppName(),
-			releaseEvent.GetPreviousAppVersion(),
-			releaseEvent.GetAppVersion(),
+			releaseEvent.GetPreviousChartVersion(),
+			releaseEvent.GetChartVersion(),
 			releaseEvent.GetNamespace(),
 			releaseEvent.GetNotes(),
 		)


### PR DESCRIPTION
 - Chart versions also added as first class primitives in JSON
   presenter.
 - App version is now visible on a new line in the message. It mentions
   if the app version is changed or not by a chart change.