### PR TITLE
Remove potentailly sensitive info from logs

### DIFF
--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -30,7 +30,7 @@ import (
 )
 
 type Handler interface {
-	Init() error
+	Init()
 	HandleEvent(releaseEvent *kwrelease.Event)
 }
 
@@ -43,8 +43,7 @@ var Map = map[string]interface{}{
 type Default struct {
 }
 
-func (d *Default) Init() error {
-	return nil
+func (d *Default) Init() {
 }
 
 func (d *Default) HandleEvent(releaseEvent *kwrelease.Event) {

--- a/handlers/slack/slack.go
+++ b/handlers/slack/slack.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"log"
 	"os"
+	"strings"
 
 	"github.com/larderdev/kubewise/kwrelease"
 	"github.com/larderdev/kubewise/presenters"
@@ -14,7 +15,7 @@ type Slack struct {
 	Channel string
 }
 
-func (s *Slack) Init() error {
+func (s *Slack) Init() {
 	channel := "#general"
 	if value, ok := os.LookupEnv("KW_SLACK_CHANNEL"); ok {
 		channel = value
@@ -29,7 +30,6 @@ func (s *Slack) Init() error {
 
 	s.Token = token
 	s.Channel = channel
-	return nil
 }
 
 func (s *Slack) HandleEvent(releaseEvent *kwrelease.Event) {
@@ -46,7 +46,7 @@ func sendMessage(s *Slack, msg string) {
 	channelID, timestamp, err := api.PostMessage(s.Channel, text, asUser)
 
 	if err != nil {
-		log.Printf("%s\n", err)
+		log.Println(strings.ReplaceAll(err.Error(), s.Token, "<slack-api-token>"))
 		return
 	}
 

--- a/kwrelease/kwrelease.go
+++ b/kwrelease/kwrelease.go
@@ -28,7 +28,7 @@ func (e *Event) Init() error {
 	currentRelease, err := driver.DecodeRelease(string(e.CurrentReleaseSecret.Data["release"]))
 
 	if err != nil {
-		log.Fatalln("Error getting releaseData from secret", e.CurrentReleaseSecret)
+		log.Fatalln("Error getting releaseData from secret with UID:", e.CurrentReleaseSecret.GetUID())
 		return err
 	}
 	e.currentRelease = currentRelease
@@ -127,7 +127,6 @@ func (e *Event) GetAction() Action {
 }
 
 func inferNameOfPreviousReleaseSecret(currentReleaseSecretName string) string {
-	log.Println("Finding previous releases of release name", currentReleaseSecretName)
 	// e.g. [sh helm release v1 airflow v2]
 	currentReleaseVersion := strings.Split(currentReleaseSecretName, ".")
 	previousReleaseVersion := make([]string, len(currentReleaseVersion))
@@ -184,7 +183,7 @@ func (e *Event) getPreviousRelease() *release.Release {
 	previousRelease, err := driver.DecodeRelease(string(previousReleaseSecret.Data["release"]))
 
 	if err != nil {
-		log.Println("Error decoding previous Helm release", previousReleaseSecret)
+		log.Println("Error decoding previous Helm release with secret UID:", previousReleaseSecret.GetUID())
 		return nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -27,11 +27,6 @@ func main() {
 		eventHandler = new(slack.Slack)
 	}
 
-	err := eventHandler.Init()
-
-	if err != nil {
-		log.Fatalln("Error initializing eventHandler", err)
-	}
-
+	eventHandler.Init()
 	controller.Start(eventHandler)
 }

--- a/utils/cluster_auth.go
+++ b/utils/cluster_auth.go
@@ -46,12 +46,12 @@ func GetClient() kubernetes.Interface {
 func GetClientInsideCluster() kubernetes.Interface {
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		log.Fatalf("Can not get kubernetes config: %v", err)
+		log.Fatalf("Can not get kubernetes config.")
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		log.Fatalf("Can not create kubernetes client: %v", err)
+		log.Fatalf("Can not create kubernetes client.")
 	}
 
 	return clientset
@@ -68,12 +68,12 @@ func buildOutOfClusterConfig() (*rest.Config, error) {
 func GetClientOutOfCluster() kubernetes.Interface {
 	config, err := buildOutOfClusterConfig()
 	if err != nil {
-		log.Fatalf("Can not get kubernetes config: %v", err)
+		log.Fatalf("Can not get kubernetes config.")
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		log.Fatalf("Can not get kubernetes config: %v", err)
+		log.Fatalf("Can not get kubernetes config.")
 	}
 
 	return clientset


### PR DESCRIPTION
 - Also altered the Handler interface to remove the option to return an
   error from the Init func. This is not needed since we're only using
   env vars to config the Handlers.
 - Audited all points in the codebase where `log.` is called to ensure
   no sensitive leaks can occur.
 - Fixed three points in the handlers where leaks could have occurred
   due to errs being logged.