### PR TITLE
Handle installation and upgrade failure

### DIFF
--- a/kwrelease/action.go
+++ b/kwrelease/action.go
@@ -14,6 +14,8 @@ const (
 	ActionPostReplace           Action = "POST_REPLACE"
 	ActionPostReplaceSuperseded Action = "POST_REPLACE-SUPERSEDED"
 	ActionPreUninstall          Action = "PRE_UNINSTALL"
+	ActionFailedInstall         Action = "FAILED_INSTALL"
+	ActionFailedReplace         Action = "FAILED_REPLACE"
 )
 
 func (a Action) String() string {

--- a/kwrelease/kwrelease.go
+++ b/kwrelease/kwrelease.go
@@ -56,8 +56,12 @@ func (e *Event) GetNamespace() string {
 	return e.currentRelease.Namespace
 }
 
-func (e *Event) GetDescription() string {
+func (e *Event) GetAppDescription() string {
 	return e.currentRelease.Chart.Metadata.Description
+}
+
+func (e *Event) GetReleaseDescription() string {
+	return e.currentRelease.Info.Description
 }
 
 func (e *Event) GetNotes() string {
@@ -120,6 +124,12 @@ func (e *Event) GetAction() Action {
 			return ActionPostUpgrade
 		}
 		return ActionPostReplace
+	} else if e.currentRelease.Info.Status == release.StatusFailed {
+		if e.previousRelease == nil {
+			return ActionFailedInstall
+		}
+		// There is no way to differentiate between an upgrade and a rollback.
+		return ActionFailedReplace
 	} else if e.currentRelease.Info.Status == release.StatusSuperseded {
 		return ActionPostReplaceSuperseded
 	}
@@ -150,7 +160,7 @@ func inferNameOfPreviousReleaseSecret(currentReleaseSecretName string) string {
 	return strings.Join(previousReleaseVersion, ".")
 }
 
-// GetPreviousRelease locates previous Helm releasees based off the name of a given secret.
+// GetPreviousRelease locates previous Helm releases based off the name of a given secret.
 // Helm 3 releases have secret names like: sh.helm.release.v1.zookeeper.v1
 // The last `v1` is incremented every time an upgrade occurs. This way, the previous releases
 // of a package can be located by looking for secrets with matching names.

--- a/presenters/json.go
+++ b/presenters/json.go
@@ -26,6 +26,7 @@ type EventJSON struct {
 	SecretUID            types.UID    `json:"secretUid"`
 	ChartVersion         string       `json:"chartVersion"`
 	PreviousChartVersion string       `json:"previousChartVersion"`
+	ReleaseDescription   string       `json:"releaseDescription"`
 }
 
 func ReleaseEventToJSON(e *kwrelease.Event) ([]byte, error) {
@@ -35,11 +36,12 @@ func ReleaseEventToJSON(e *kwrelease.Event) ([]byte, error) {
 		Namespace:            e.GetNamespace(),
 		Action:               e.GetAction().String(),
 		InstallNotes:         e.GetNotes(),
-		AppDescription:       e.GetDescription(),
+		AppDescription:       e.GetAppDescription(),
 		CreatedAt:            e.GetSecretCreationTimestamp(),
 		SecretUID:            e.GetSecretUID(),
 		ChartVersion:         e.GetChartVersion(),
 		PreviousChartVersion: e.GetPreviousChartVersion(),
+		ReleaseDescription:   e.GetReleaseDescription(),
 	}
 
 	if value := e.GetLabelsModifiedAtTimestamp(); !value.IsZero() {

--- a/presenters/presenters.go
+++ b/presenters/presenters.go
@@ -36,7 +36,7 @@ func PrepareMsg(releaseEvent *kwrelease.Event) string {
 			releaseEvent.GetChartVersion(),
 			releaseEvent.GetNamespace(),
 			releaseEvent.GetAppVersion(),
-			releaseEvent.GetDescription(),
+			releaseEvent.GetAppDescription(),
 		)
 
 	case kwrelease.ActionPreUpgrade:
@@ -96,6 +96,24 @@ func PrepareMsg(releaseEvent *kwrelease.Event) string {
 			releaseEvent.GetChartVersion(),
 			releaseEvent.GetNamespace(),
 			releaseEvent.GetNotes(),
+		)
+
+	case kwrelease.ActionFailedInstall:
+		msg += fmt.Sprintf("❌ Installation of *%s* version *%s* in namespace *%s* has FAILED. ❌\n\n```%s```",
+			releaseEvent.GetAppName(),
+			releaseEvent.GetChartVersion(),
+			releaseEvent.GetNamespace(),
+			// This has the cause of the failure.
+			releaseEvent.GetReleaseDescription(),
+		)
+
+	case kwrelease.ActionFailedReplace:
+		msg += fmt.Sprintf("❌ Replacing *%s* version %s with version *%s* in namespace *%s* has FAILED. ❌\n\n```%s```",
+			releaseEvent.GetAppName(),
+			releaseEvent.GetPreviousChartVersion(),
+			releaseEvent.GetChartVersion(),
+			releaseEvent.GetNamespace(),
+			releaseEvent.GetReleaseDescription(),
 		)
 	}
 


### PR DESCRIPTION
A reliable way to trigger a failure is to try to install a chart with an
invalid `image.tag`, and the `--wait and --timeout 10s` flags. The pod
will fail to come up because of `ErrImagePull` and the installation will
fail once the timeout is hit.