### PR TITLE
Fixes #47 Make clusterRoleBinding optional

### DIFF
--- a/helm_chart/templates/rolebinding.yaml
+++ b/helm_chart/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
-{{- if and .Values.rbac.create (eq .Values.clusterRole.create true) -}}
-kind: ClusterRole
+{{- if and .Values.rbac.create (eq .Values.clusterRole.create false) -}}
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "kubewise.serviceAccountName" . }}
@@ -8,16 +8,16 @@ rules:
   resources: ["secrets"]
   verbs: ["list", "get", "watch"]
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "kubewise.serviceAccountName" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "kubewise.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: {{ include "kubewise.serviceAccountName" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -39,6 +39,15 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: kubewise
 
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+# If create is `false` Kubewise will be restricted to the namespace
+# where it is deployed, and no ClusterRole or ClusterRoleBinding will be created.
+clusterRole:
+  create: true
+
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
This simply allows deployment into environments where we are unable to create a clusterRole or clusterRoleBinding due to access restrictions (we are limited to a single namespace).